### PR TITLE
Add some links including EU initiative + Telegram channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ This site contains information about resources for Ukrainian researchers and stu
 * [Institute of Organic Chemistry and Biochemistry (IOCB) Prague, Czech Academy of Sciences](https://www.uochb.cz/en/news/401/employment-offer-for-ukrainian-researchers-and-phd-students)
 * [EU-LIFE institutes](https://eu-life.eu/newsroom/news/ukraine)
 
+##  TRANSLATION_NEEDED| Fellowship for students
+
+* [CEE special fellowship programme for Ukraine ](https://www.dbu.de/3046.html) for Msc and PhD students
+
 
 ## Заяви на підтримку | Support statements
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This site contains information about resources for Ukrainian researchers and stu
 
 ### Глобальні ресурси | Global resources
 
+* [ERA4Ukraine](https://euraxess.ec.europa.eu/ukraine) is a EU initiative to provide Ukrainian researchers with an overview of all existing actions at European and national levels
 * https://bit.ly/ua-table - maintained by our group (to add new entries use https://bit.ly/ua-form, for questions contact ukraine@galaxyproject.org)
 * https://www.embo.org/solidarity-with-ukraine - maintained by EMBO (new entries can be added directly from the webpage)
 * https://scienceforukraine.eu - maintained by the "ScienceForUkraine" initiative (contact information is [here](https://scienceforukraine.eu/team.html))

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This site contains information about resources for Ukrainian researchers and stu
 * [EAPIL list of support](https://eapil.org/2022/03/10/funding-opportunities-and-help-for-scholars-from-ukraine-russia-and-belarus)
 * [Jobs4Ukraine](https://jobsforukraine.net/industry) - a curated, EU-wide list of companies that can take up refugee workers and technical staff with immediate effect, and a registry of white- and blue-collar workers seeking jobs. Co-founded by Marcin Ratajczak (CEO of [Inuru GmbH](https://www.inuru.com)).
 * [Job Aid for Ukrainain Refugees](https://www.jobaidukraine.com/) - similar to previous link
+* [Image Ukraine](https://imagine-ukraine.org/) advertise jobs for Ukrainians (white-collar)
 * [Отримати домопогу/Get help](https://www.standwithukraine.app/ua/#receive-title) verified global and European aid sources
 [^1]: https://bit.ly/ua-form
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ This site contains information about resources for Ukrainian researchers and stu
 ## Місцева підтримка біженців | Local support for refugees
 
 ###  Німеччина | Germany
+* [Help Ukraine Gemany](https://t.me/helpUkraine_Gemany) is a Telegram channel for Ukrainians in Germany
 
   #### Berlin
   * [Information for Volunteers](https://info.arrivalsupport.berlin)

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ This site contains information about resources for Ukrainian researchers and stu
   * [Information for Volunteers](https://info.arrivalsupport.berlin)
   * [Ukraine Berlin Arrival Support](https://t.me/ukraineberlinarrivalsupport) is a Telegram channel for coordonating support
   * [Ukraine Help Berlin](https://t.me/ukrainehelpberlin) is a Telegram channel about housing in Berlin
+  * [Vitsche](https://linktr.ee/ukrainehelpberlin) is a new association of young committed Ukrainians from Berlin
 
   #### Freiburg
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ university
 
   * [Useful links (consulate, associations) from the City mayor](https://www.lyon.fr/actualite/solidarite/la-ville-de-lyon-et-ses-habitantes-aux-cotes-de-la-population-ukrainien)
 
-### Belgien
+### Бельгія | Belgium
 
 * [ULB Brussels](https://actus.ulb.be/help-ukraine-academic-community)
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This site contains information about resources for Ukrainian researchers and stu
 * [Institute of Organic Chemistry and Biochemistry (IOCB) Prague, Czech Academy of Sciences](https://www.uochb.cz/en/news/401/employment-offer-for-ukrainian-researchers-and-phd-students)
 * [EU-LIFE institutes](https://eu-life.eu/newsroom/news/ukraine)
 
-##  TRANSLATION_NEEDED| Fellowship for students
+## Студентська стипендія | Fellowship for students
 
 * [CEE special fellowship programme for Ukraine ](https://www.dbu.de/3046.html) for Msc and PhD students
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ This site contains information about resources for Ukrainian researchers and stu
 * private Vermittlung www.unterkunft-ukraine.de
 * private Vermittlung www.warmes-bett.de
 * [Europe Network for refugees](https://www.warhelp.eu/places)
-* [Point](https://pointsite.vercel.app/)
-* [Berlin Telegram](https://t.me/BerlinHostUkranians)
+* [Point](https://pointsite.vercel.app/) is an app for both finding or sharing a place
+* [Berlin Host Ukrainians](https://t.me/BerlinHostUkranians) is a Telegram channel about housing in Berlin
 
 ## Організації допомоги | Aid organisations
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ This site contains information about resources for Ukrainian researchers and stu
 * [Institute of Organic Chemistry and Biochemistry (IOCB) Prague, Czech Academy of Sciences](https://www.uochb.cz/en/news/401/employment-offer-for-ukrainian-researchers-and-phd-students)
 * [EU-LIFE institutes](https://eu-life.eu/newsroom/news/ukraine)
 
-## Студентська стипендія | Fellowship for students
+## Стипендія | Fellowship for students
 
 * [CEE special fellowship programme for Ukraine ](https://www.dbu.de/3046.html) for Msc and PhD students
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ This site contains information about resources for Ukrainian researchers and stu
 * private Vermittlung www.unterkunft-ukraine.de
 * private Vermittlung www.warmes-bett.de
 * [Europe Network for refugees](https://www.warhelp.eu/places)
+* [Point](https://pointsite.vercel.app/)
+* [Berlin Telegram](https://t.me/BerlinHostUkranians)
 
 ## Організації допомоги | Aid organisations
 

--- a/README.md
+++ b/README.md
@@ -100,10 +100,18 @@ This site contains information about resources for Ukrainian researchers and stu
 
 ## Місцева підтримка біженців | Local support for refugees
 
+### Польща | Poland
+
+  #### Krakow
+   
+  * [Krakow Help](https://t.me/krakowhelpmain) is a Telegram channel dedicated to helping Ukrainians
+
 ###  Німеччина | Germany
+
 * [Help Ukraine Gemany](https://t.me/helpUkraine_Gemany) is a Telegram channel for Ukrainians in Germany
 
   #### Berlin
+  
   * [Information for Volunteers](https://info.arrivalsupport.berlin)
   * [Ukraine Berlin Arrival Support](https://t.me/ukraineberlinarrivalsupport) is a Telegram channel for coordonating support
   * [Ukraine Help Berlin](https://t.me/ukrainehelpberlin) is a Telegram channel about housing in Berlin
@@ -120,6 +128,26 @@ This site contains information about resources for Ukrainian researchers and stu
   #### Munich
 
   * [TUM-IAS Fellowships](https://www.ias.tum.de/ias/news/news-single-view/article/tum-ias-fellowships-for-researchers-from-the-ukraine/)
+
+  #### Other German cities (Telegram)
+  
+  * [Bielefeld](https://t.me/bielefeldhelps)
+  * [Bremen](https://t.me/ukrainebremen)
+  * [Braunschweig](https://t.me/BS_UA_HELP)
+  * [Chemnitz](https://t.me/pomosh_Germany_Chemnitz_Ukraine)
+  * [Dresden](https://t.me/djV5nXL6pWdlYmQ6)
+  * [Duisburg](https://t.me/duisburgukraine)
+  * [Essen](https://t.me/ukr_de_essen)
+  * [Hamburg](https://t.me/hamburg_hilft)
+  * [Köln](https://t.me/cologne_help)
+  * [Leipzig](https://t.me/ukrainerinleipzig)
+  * [Magdeburg](https://t.me/magdeburg_ukraine)
+  * [Nürnberg](https://t.me/help_in_Nuremberg_UA)
+  * [Rheinland-Pfalz](https://t.me/ukrainerheinlandpfalz)
+  * [Saarland](https://t.me/ukrainesaarland)
+  * [Stuttgart Raum](https://t.me/helpforukraine22)
+  * [Thüringen](https://t.me/thuringia_stands_with_ukraine)
+  * [Thüringen bis](https://t.me/th_helps_ukraine)
 
 ###  Чехія | Czechia 
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ This site contains information about resources for Ukrainian researchers and stu
 * private Vermittlung www.warmes-bett.de
 * [Europe Network for refugees](https://www.warhelp.eu/places)
 * [Point](https://pointsite.vercel.app/) is an app for both finding or sharing a place
-* [Berlin Host Ukrainians](https://t.me/BerlinHostUkranians) is a Telegram channel about housing in Berlin
 
 ## Організації допомоги | Aid organisations
 
@@ -102,6 +101,11 @@ This site contains information about resources for Ukrainian researchers and stu
 ## Місцева підтримка біженців | Local support for refugees
 
 ###  Німеччина | Germany
+
+  #### Berlin
+  * [Information for Volunteers](https://info.arrivalsupport.berlin)
+  * [Ukraine Berlin Arrival Support](https://t.me/ukraineberlinarrivalsupport) is a Telegram channel for coordonating support
+  * [Ukraine Help Berlin](https://t.me/ukrainehelpberlin) is a Telegram channel about housing in Berlin
 
   #### Freiburg
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This site contains information about resources for Ukrainian researchers and stu
 * https://scienceforukraine.eu - maintained by the "ScienceForUkraine" initiative (contact information is [here](https://scienceforukraine.eu/team.html))
 * [EAPIL list of support](https://eapil.org/2022/03/10/funding-opportunities-and-help-for-scholars-from-ukraine-russia-and-belarus)
 * [Jobs4Ukraine](https://jobsforukraine.net/industry) - a curated, EU-wide list of companies that can take up refugee workers and technical staff with immediate effect, and a registry of white- and blue-collar workers seeking jobs. Co-founded by Marcin Ratajczak (CEO of [Inuru GmbH](https://www.inuru.com)).
+* [Job Aid for Ukrainain Refugees](https://www.jobaidukraine.com/) - similar to previous link
 * [Отримати домопогу/Get help](https://www.standwithukraine.app/ua/#receive-title) verified global and European aid sources
 [^1]: https://bit.ly/ua-form
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ This site contains information about resources for Ukrainian researchers and stu
 ###  Німеччина | Germany
 
 * [Help Ukraine Gemany](https://t.me/helpUkraine_Gemany) is a Telegram channel for Ukrainians in Germany
+* [Deutsch-Ukrainische Akademische Gesellschaft / the German-Ukrainian Academic Society](https://ukrainet.eu/)
 
   #### Berlin
   

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ This site contains information about resources for Ukrainian researchers and stu
 * [France Universités](https://franceuniversites.fr/actualite/france-universites-solidaire-des-universites-ukrainiennes/)
 * [The Guild of European Research-Intensive Universities](https://www.the-guild.eu/news/2022/europe’s-universities-must-stand-up-for-democracy.html)
 * [German Rectors' Conference (HRK)](https://www.hrk.de/press/press-releases/press-release/meldung/solidarity-with-ukraine-and-ukrainian-universities-hrk-condemns-russian-attack-4888/)
+* [FU Berlin](https://www.fu-berlin.de/en/universitaet/ukraine/index.html)
 
 
 ## Місцева підтримка біженців | Local support for refugees


### PR DESCRIPTION
I added the new ERA4Ukraine link that is a very important one (EU specific initiative to compile all info).

Also, many Ukrainians rely heavily on Telegram to share information and thus very large channel of Ukrainian refugees and helpers are emerging on Telegram. In Berlin for instance, several channels have more than 15,000 subscribers.
So, I have been adding many Telegram links.

I also added a few other links.

I am not sure what to do with the general links for jobs that are not academic jobs, but I put the link just in case (lines 31, 32).

++
